### PR TITLE
Create the tokio runtime manually

### DIFF
--- a/narupa-rs/src/simulation.rs
+++ b/narupa-rs/src/simulation.rs
@@ -1,5 +1,5 @@
 extern crate openmm_sys;
-use log::{debug, warn, trace};
+use log::{debug, trace, warn};
 use thiserror::Error;
 
 use openmm_sys::{
@@ -12,16 +12,16 @@ use openmm_sys::{
     OpenMM_DoubleArray_set, OpenMM_Force, OpenMM_Integrator, OpenMM_Integrator_destroy,
     OpenMM_Integrator_step, OpenMM_Platform_getName, OpenMM_Platform_getNumPlatforms,
     OpenMM_Platform_loadPluginsFromDirectory, OpenMM_State,
-    OpenMM_State_DataType_OpenMM_State_Positions, OpenMM_State_DataType_OpenMM_State_Velocities,
-    OpenMM_State_DataType_OpenMM_State_Forces, OpenMM_State_DataType_OpenMM_State_Energy,
-    OpenMM_State_DataType_OpenMM_State_Parameters, OpenMM_State_DataType_OpenMM_State_ParameterDerivatives,
-    OpenMM_State_destroy,
-    OpenMM_State_getPeriodicBoxVectors, OpenMM_State_getPositions, OpenMM_System,
-    OpenMM_System_addForce, OpenMM_System_destroy, OpenMM_System_getNumParticles,
-    OpenMM_System_getParticleMass, OpenMM_Vec3, OpenMM_Vec3Array, OpenMM_Vec3Array_create,
-    OpenMM_Vec3Array_destroy, OpenMM_Vec3Array_get, OpenMM_Vec3Array_getSize, OpenMM_Vec3Array_set,
-    OpenMM_Vec3_scale, OpenMM_XmlSerializer_deserializeIntegrator,
-    OpenMM_XmlSerializer_deserializeSystem, OpenMM_State_getKineticEnergy, OpenMM_State_getPotentialEnergy,
+    OpenMM_State_DataType_OpenMM_State_Energy, OpenMM_State_DataType_OpenMM_State_Forces,
+    OpenMM_State_DataType_OpenMM_State_ParameterDerivatives,
+    OpenMM_State_DataType_OpenMM_State_Parameters, OpenMM_State_DataType_OpenMM_State_Positions,
+    OpenMM_State_DataType_OpenMM_State_Velocities, OpenMM_State_destroy,
+    OpenMM_State_getKineticEnergy, OpenMM_State_getPeriodicBoxVectors, OpenMM_State_getPositions,
+    OpenMM_State_getPotentialEnergy, OpenMM_System, OpenMM_System_addForce, OpenMM_System_destroy,
+    OpenMM_System_getNumParticles, OpenMM_System_getParticleMass, OpenMM_Vec3, OpenMM_Vec3Array,
+    OpenMM_Vec3Array_create, OpenMM_Vec3Array_destroy, OpenMM_Vec3Array_get,
+    OpenMM_Vec3Array_getSize, OpenMM_Vec3Array_set, OpenMM_Vec3_scale,
+    OpenMM_XmlSerializer_deserializeIntegrator, OpenMM_XmlSerializer_deserializeSystem,
 };
 use quick_xml::events::{BytesEnd, BytesStart, Event};
 use quick_xml::Reader;
@@ -32,8 +32,8 @@ use std::ffi::{CStr, CString};
 use std::io::{BufReader, Cursor, Read};
 use std::str;
 
-use narupa_proto::frame::FrameData;
 use crate::parsers::{errors::ReadError, read_cif, read_pdb, MolecularSystem};
+use narupa_proto::frame::FrameData;
 
 type Coordinate = [f64; 3];
 type CoordMap = BTreeMap<i32, Coordinate>;
@@ -393,14 +393,13 @@ impl OpenMMSimulation {
 
             let initial_state = OpenMM_Context_getState(
                 context,
-                (
-                    OpenMM_State_DataType_OpenMM_State_Positions
+                (OpenMM_State_DataType_OpenMM_State_Positions
                     | OpenMM_State_DataType_OpenMM_State_Velocities
                     | OpenMM_State_DataType_OpenMM_State_Forces
                     | OpenMM_State_DataType_OpenMM_State_Energy
                     | OpenMM_State_DataType_OpenMM_State_Parameters
-                    | OpenMM_State_DataType_OpenMM_State_ParameterDerivatives
-                ) as i32,
+                    | OpenMM_State_DataType_OpenMM_State_ParameterDerivatives)
+                    as i32,
                 0,
             );
 
@@ -563,10 +562,8 @@ impl ToFrameData for OpenMMSimulation {
         unsafe {
             let state = OpenMM_Context_getState(
                 self.context,
-                (
-                    OpenMM_State_DataType_OpenMM_State_Positions
-                    | OpenMM_State_DataType_OpenMM_State_Energy
-                ) as i32,
+                (OpenMM_State_DataType_OpenMM_State_Positions
+                    | OpenMM_State_DataType_OpenMM_State_Energy) as i32,
                 0,
             );
 
@@ -616,11 +613,11 @@ impl ToFrameData for OpenMMSimulation {
             .insert_number_value("energy.potential", potential_energy)
             .unwrap();
         frame
-           .insert_number_value("energy.kinetic", kinetic_energy)
-           .unwrap();
+            .insert_number_value("energy.kinetic", kinetic_energy)
+            .unwrap();
         frame
-           .insert_number_value("energy.total", total_energy)
-           .unwrap();
+            .insert_number_value("energy.total", total_energy)
+            .unwrap();
         frame
             .insert_number_value("particle.count", (positions.len() / 3) as f64)
             .unwrap();


### PR DESCRIPTION
This is necessary to build the UI as UI frameworks need to manage their own event loop. (Needed for #12)

This required to refactor some of the error handling.

Fixes #109