### PR TITLE
Add the ability to start the server paused

### DIFF
--- a/narupa-rs/src/application.rs
+++ b/narupa-rs/src/application.rs
@@ -171,6 +171,9 @@ pub struct Cli {
     /// Record the updates from the shared state
     #[clap(long, value_parser)]
     pub state: Option<String>,
+    /// Start the simulation paused
+    #[clap(long, value_parser, default_value_t = false)]
+    pub start_paused: bool,
 }
 
 impl Default for Cli {
@@ -190,6 +193,7 @@ impl Default for Cli {
             name: "Narupa-RS iMD Server".to_owned(),
             trajectory: None,
             state: None,
+            start_paused: false,
         }
     }
 }
@@ -423,6 +427,7 @@ pub async fn main_to_wrap(cli: Cli, cancel_rx: CancellationReceivers) -> Result<
         playback_rx,
         simulation_tx,
         true,
+        !cli.start_paused,
     )?;
 
     // Advertise the server with ESSD

--- a/narupa-rs/src/bin/narupa-gui.rs
+++ b/narupa-rs/src/bin/narupa-gui.rs
@@ -367,6 +367,7 @@ struct MyEguiApp {
     trajectory: Option<String>,
     record_state: bool,
     state: Option<String>,
+    start_paused: bool,
 }
 
 impl Default for MyEguiApp {
@@ -399,6 +400,7 @@ impl Default for MyEguiApp {
             trajectory: None,
             record_state: false,
             state: None,
+            start_paused: reference.start_paused,
         }
     }
 }
@@ -508,6 +510,7 @@ impl MyEguiApp {
             self.simulation_fps.widget(ui);
             self.frame_interval.widget(ui);
             self.force_interval.widget(ui);
+            ui.checkbox(&mut self.start_paused, "Start simulation paused");
         });
     }
 
@@ -730,6 +733,7 @@ impl MyEguiApp {
         let simulation_fps = self.simulation_fps.convert().map_err(|_| ())?;
         let frame_interval = self.frame_interval.convert().map_err(|_| ())?;
         let force_interval = self.force_interval.convert().map_err(|_| ())?;
+        let start_paused = self.start_paused;
 
         let mut arguments = Cli {
             port,
@@ -738,6 +742,7 @@ impl MyEguiApp {
             force_interval,
             progression: self.show_progression,
             name: self.server_name.clone(),
+            start_paused,
             ..Default::default()
         };
 

--- a/narupa-rs/src/simulation_thread.rs
+++ b/narupa-rs/src/simulation_thread.rs
@@ -55,6 +55,7 @@ pub fn run_simulation_thread(
     mut playback_rx: Receiver<PlaybackOrder>,
     simulation_tx: std::sync::mpsc::Sender<usize>,
     auto_reset: bool,
+    run_on_start: bool
 ) -> Result<(), XMLParsingError> {
     let mut maybe_simulation: Option<OpenMMSimulation> = match simulations_manifest.load_default() {
         Ok(simulation) => Some(simulation),
@@ -69,7 +70,7 @@ pub fn run_simulation_thread(
     };
 
     tokio::task::spawn_blocking(move || {
-        let mut playback_state = PlaybackState::new(true);
+        let mut playback_state = PlaybackState::new(run_on_start);
         let interval = Duration::from_millis(simulation_interval);
         if let Some(ref simulation) = maybe_simulation {
             if sim_clone


### PR DESCRIPTION
From the CLI, this is accessible with the --start-paused option. From the GUI there is a "Start simulation paused" checkbox in the "Simulation" section.

Fixes #151