### PR TITLE
In the GUI, remove the client when we remove the server

### DIFF
--- a/narupa-rs/src/bin/narupa-gui.rs
+++ b/narupa-rs/src/bin/narupa-gui.rs
@@ -898,6 +898,10 @@ impl MyEguiApp {
             let Some(server) = self.server.take() else {return};
             let Err(error) = self.runtime.block_on(server.close()).unwrap() else {return};
             self.error = Some(format!("{error}"));
+            // If we do not have a server anymore, we should not have a client
+            // either. Otherwise, we end up with a mismatch when we connect a
+            // different server and the interface gets stucked.
+            self.client = None;
         }
     }
 


### PR DESCRIPTION
When the server fails to connect, the server gets removed but not the client. Ehen we then connect with a different server (changing a used port for a free one, for instance) we have a mismatch between the server and the client so client requestget stuck and the UI freezes.

Here, we clear the client when the server errors to avoid the issue. Stopping the server with the Stop button was already clearing the client.