### PR TITLE
Fail clippy on warnings in CI

### DIFF
--- a/narupa-rs/src/application.rs
+++ b/narupa-rs/src/application.rs
@@ -56,7 +56,7 @@ pub struct CancellationReceivers {
 }
 
 impl CancellationReceivers {
-    //#[allow(clippy::type_complexity)]
+    #[allow(clippy::type_complexity)]
     pub fn unpack(
         self,
     ) -> (


### PR DESCRIPTION
Warnings do not cause clippy to fail when running on CI. This PR fixes it.