### PR TITLE
Fix the default force interval in the GUI

### DIFF
--- a/narupa-rs/src/application.rs
+++ b/narupa-rs/src/application.rs
@@ -193,7 +193,7 @@ impl Default for Cli {
             port: 38801,
             simulation_fps: 30.0,
             frame_interval: 5,
-            force_interval: 10,
+            force_interval: 5,
             progression: false,
             verbose: false,
             trace: false,


### PR DESCRIPTION
While #177 changed the defaukt value of the force interval in the CLI, it failed to change it in the GUI. This commit changes the value in the GUI to be consistent with the CLI.