### PR TITLE
Include velocities and forces in the FrameData

### DIFF
--- a/narupa-rs/src/application.rs
+++ b/narupa-rs/src/application.rs
@@ -183,6 +183,12 @@ pub struct Cli {
     /// Start the simulation paused
     #[clap(long, value_parser, default_value_t = false)]
     pub start_paused: bool,
+    // Include the velocities in the FrameData
+    #[clap(long, value_parser, default_value_t = false)]
+    pub include_velocity: bool,
+    // Include the forces in the FrameData
+    #[clap(long, value_parser, default_value_t = false)]
+    pub include_forces: bool,
 }
 
 impl Default for Cli {
@@ -203,6 +209,8 @@ impl Default for Cli {
             trajectory: None,
             state: None,
             start_paused: false,
+            include_velocity: false,
+            include_forces: false,
         }
     }
 }
@@ -451,6 +459,8 @@ pub async fn main_to_wrap(
         simulation_tx,
         true,
         !cli.start_paused,
+        cli.include_velocity,
+        cli.include_forces,
     )?;
 
     // Advertise the server with ESSD

--- a/narupa-rs/src/bin/narupa-gui.rs
+++ b/narupa-rs/src/bin/narupa-gui.rs
@@ -384,6 +384,8 @@ struct MyEguiApp {
     record_state: bool,
     state: Option<String>,
     start_paused: bool,
+    with_velocities: bool,
+    with_forces: bool,
 }
 
 impl Default for MyEguiApp {
@@ -417,6 +419,8 @@ impl Default for MyEguiApp {
             record_state: false,
             state: None,
             start_paused: reference.start_paused,
+            with_velocities: reference.include_velocity,
+            with_forces: reference.include_forces,
         }
     }
 }
@@ -527,6 +531,11 @@ impl MyEguiApp {
             self.frame_interval.widget(ui);
             self.force_interval.widget(ui);
             ui.checkbox(&mut self.start_paused, "Start simulation paused");
+            ui.checkbox(
+                &mut self.with_velocities,
+                "Include the velocities in the frames",
+            );
+            ui.checkbox(&mut self.with_forces, "Include the forces in the frames");
         });
     }
 
@@ -755,6 +764,8 @@ impl MyEguiApp {
         let frame_interval = self.frame_interval.convert().map_err(|_| ())?;
         let force_interval = self.force_interval.convert().map_err(|_| ())?;
         let start_paused = self.start_paused;
+        let include_velocity = self.with_velocities;
+        let include_forces = self.with_forces;
 
         let mut arguments = Cli {
             port,
@@ -764,6 +775,8 @@ impl MyEguiApp {
             progression: self.show_progression,
             name: self.server_name.clone(),
             start_paused,
+            include_velocity,
+            include_forces,
             ..Default::default()
         };
 


### PR DESCRIPTION
Add the --include-velocities and --include-forces flags to the command line, and the corresponding check boxes in the GUI. These flags let a server include the velocities and forces for all atoms in the FrameData so it can be used by a client or recorded to file.

A visual client could use the data to colour particles or display force vectors. More interestigly, the data can be used in analyses later on.

Fixes #185