### PR TITLE
Remove local path from narupa-proto

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,5 +10,5 @@ On Fedora, these requirements can be installed with the following commands:
 
 ```bash
 sudo dnf groupinstall "Development Tools" "Development Libraries" "C Development Tools and Libraries"
-sudo dnf install gtk3-devel protobuf-compiler
+sudo dnf install gtk3-devel protobuf-compiler protobuf-devel
 ```

--- a/narupa-proto/build.rs
+++ b/narupa-proto/build.rs
@@ -12,10 +12,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             // "proto/narupa/protocol/instance/representation_service.proto",
             "proto/narupa/protocol/command/command_service.proto",
         ],
-        &[
-            "proto",
-            "../../../Anaconda3/envs/narupa/Lib/site-packages/grpc_tools/_proto",
-        ],
+        &["proto"],
     )?;
 
     Ok(())


### PR DESCRIPTION
narupa-proto was refering to files on my disk but out of the project. These files were the proto file for the protobuf well known types (e.g. struct and value) in my conda environemnt. I do not need to refer to these files. Instead, I should install them alongside protoc. On ubuntu, this is done by installing the `protobuf-dev` package; on fedore, the `protobuf-devel` package.

This is now documented for fedora in the README.