### PR TITLE
Do not build for openCL on Windows CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,7 @@ jobs:
         env:
           RUST_BACKTRACE: full
           RUST_LOG: trace
+          OPENMM_CMAKE_OPTIONS: OPENMM_BUILD_OPENCL_LIB=OFF
   macos_tests:
     name: Rust tests on MacOS
     runs-on: macos-14


### PR DESCRIPTION
This fixes the systematic error reported by @hjstroud in https://github.com/IRL2/nanover-rs/issues/219#issuecomment-2162619952

```
error: failed to run custom build command for openmm-sys v7.7.0 (D:\a\nanover-rs\nanover-rs\openmm-sys)

Caused by: process didn't exit successfully: D:\a\nanover-rs\nanover-rs\target\debug\build\openmm-sys-4c39ec42c80e4017\build-script-build (exit code: 101)
```

The error was caused by trying to compile OpenMM for OpenCL while the OpenCL compiler was not available. This PR specifies that the test build should not include support for OpenCL. It should remain available in the artefact build for which we install CUDA.

The intermittent error about foreign exceptions not being caught remains, though. It is due to a more profound issue with the OpenMM bindings. See #2.