### PR TITLE
Add corrected potential energies to FrameData

### DIFF
--- a/nanover-rs/src/simulation.rs
+++ b/nanover-rs/src/simulation.rs
@@ -538,50 +538,8 @@ impl OpenMMSimulation {
 
     /// # Safety
     ///
-    /// This function returns the positions of the system from an OpenMM state, but perhaps it is only necessary to retrieve the selection positions
-    /// TODO: investigate whether this function can be rewritten to only return desired selections
-    pub unsafe fn get_positions(&self) -> Vec<Coordinate> {
-        let state = OpenMM_Context_getState(
-            self.context,
-            OpenMM_State_DataType_OpenMM_State_Positions as i32,
-            0,
-        );
-        let pos_state = OpenMM_State_getPositions(state);
-
-        let mut positions = Vec::<Coordinate>::new();
-
-        for index in 0..self.n_particles {
-            let particle_position =
-                OpenMM_Vec3_scale(*OpenMM_Vec3Array_get(pos_state, index as i32), 1.0);
-            let position = [
-                particle_position.x,
-                particle_position.y,
-                particle_position.z,
-            ];
-            positions.push(position);
-        }
-
-        OpenMM_State_destroy(state);
-
-        positions
-    }
-
-    pub unsafe fn get_selected_positions(&self, selection: Vec<i32>) -> Vec<[f64; 3]> {
-        let state = OpenMM_Context_getState(
-            self.context,
-            OpenMM_State_DataType_OpenMM_State_Positions as i32,
-            0,
-        );
-        let positions = OpenMM_State_getPositions(state);
-
-        let selected_positions = get_selection_positions_from_state_positions(&selection, positions);
-
-        OpenMM_State_destroy(state);
-
-        selected_positions
-    }
-
-    pub unsafe fn get_selected_positions_coord_map(&self, indices: &HashSet<i32>) -> CoordMap {
+    /// A function that accepts a &HashSet<i32> denoting a selection of atoms and returns the positions of those atoms as a CoordMap
+    pub unsafe fn get_selected_positions(&self, indices: &HashSet<i32>) -> CoordMap {
         let state = OpenMM_Context_getState(
             self.context,
             OpenMM_State_DataType_OpenMM_State_Positions as i32,

--- a/nanover-rs/src/simulation.rs
+++ b/nanover-rs/src/simulation.rs
@@ -550,7 +550,10 @@ impl OpenMMSimulation {
         let mut selected_positions_map = BTreeMap::new();
 
         indices.iter().for_each(|i| {
-            selected_positions_map.insert(*i as usize, get_selected_position_from_state_positions(i, positions));
+            selected_positions_map.insert(
+                *i as usize,
+                get_selected_position_from_state_positions(i, positions),
+            );
         });
 
         OpenMM_State_destroy(state);

--- a/nanover-rs/src/simulation.rs
+++ b/nanover-rs/src/simulation.rs
@@ -536,6 +536,58 @@ impl OpenMMSimulation {
         }
     }
 
+    pub fn get_positions(&self) -> *const OpenMM_Vec3Array {
+        unsafe {
+            let state = OpenMM_Context_getState(
+                self.context,
+                OpenMM_State_DataType_OpenMM_State_Positions as i32,
+                0,
+            );
+            let pos_state = OpenMM_State_getPositions(state);
+
+            OpenMM_State_destroy(state);
+
+            pos_state
+        }
+    }
+
+    pub fn get_particle_position(&self, positions: &OpenMM_Vec3Array, index: i32) -> Coordinate {
+
+        unsafe{
+            let mut position = [0.0, 0.0, 0.0];
+            let particle_position = OpenMM_Vec3_scale(
+                *OpenMM_Vec3Array_get(positions, index),
+                1.0
+            );
+            position = [
+                particle_position.x,
+                particle_position.y,
+                particle_position.z,
+            ];
+
+            position
+
+        }
+
+    }
+
+    pub fn get_potential_energy(&self) -> f64 {
+        let potential_energy;
+
+        unsafe {
+            let state = OpenMM_Context_getState(
+                self.context,
+                OpenMM_State_DataType_OpenMM_State_Energy as i32,
+                0,
+            );
+            potential_energy = OpenMM_State_getPotentialEnergy(state);
+
+            OpenMM_State_destroy(state);
+        }
+
+        potential_energy
+    }
+
     pub fn reset_state(&mut self) {
         unsafe {
             OpenMM_Context_setState(self.context, self.initial_state);

--- a/nanover-rs/src/simulation.rs
+++ b/nanover-rs/src/simulation.rs
@@ -1072,9 +1072,8 @@ unsafe fn get_selected_position_from_state_positions(
     pos_state: *const OpenMM_Vec3Array,
 ) -> Coordinate {
     let position = OpenMM_Vec3_scale(*OpenMM_Vec3Array_get(pos_state, *selection), 1.0);
-    let selected_position = [position.x, position.y, position.z];
 
-    selected_position
+    [position.x, position.y, position.z]
 }
 
 fn get_masses_for_selection(selection: &[i32], masses: &[f64]) -> Vec<f64> {

--- a/nanover-rs/src/simulation.rs
+++ b/nanover-rs/src/simulation.rs
@@ -551,7 +551,7 @@ impl OpenMMSimulation {
         }
     }
 
-    pub fn get_particle_position(&self, positions: &OpenMM_Vec3Array, index: i32) -> Coordinate {
+    pub fn get_particle_position(&self, positions: *const OpenMM_Vec3Array, index: i32) -> Coordinate {
 
         unsafe{
             let mut position = [0.0, 0.0, 0.0];

--- a/nanover-rs/src/simulation.rs
+++ b/nanover-rs/src/simulation.rs
@@ -536,7 +536,7 @@ impl OpenMMSimulation {
         }
     }
 
-    unsafe fn get_positions(&self) -> *const OpenMM_Vec3Array {
+    pub unsafe fn get_positions(&self) -> *const OpenMM_Vec3Array {
 
         let state = OpenMM_Context_getState(
             self.context,
@@ -551,7 +551,7 @@ impl OpenMMSimulation {
 
     }
 
-    unsafe fn get_particle_position(
+    pub unsafe fn get_particle_position(
         &self,
         positions: *const OpenMM_Vec3Array,
         index: i32,

--- a/nanover-rs/src/simulation.rs
+++ b/nanover-rs/src/simulation.rs
@@ -536,7 +536,7 @@ impl OpenMMSimulation {
         }
     }
 
-    pub unsafe fn get_positions(&self) -> *const OpenMM_Vec3Array {
+    pub unsafe fn get_positions(&self) -> Vec<Coordinate> {
 
         let state = OpenMM_Context_getState(
             self.context,
@@ -545,26 +545,21 @@ impl OpenMMSimulation {
         );
         let pos_state = OpenMM_State_getPositions(state);
 
+        let mut positions = Vec::<Coordinate>::new();
+
+        for index in 0..self.n_particles {
+            let particle_position = OpenMM_Vec3_scale(*OpenMM_Vec3Array_get(pos_state, index as i32), 1.0);
+            let position = [
+                particle_position.x,
+                particle_position.y,
+                particle_position.z,
+            ];
+            positions.push(position);
+        }
+
         OpenMM_State_destroy(state);
 
-        pos_state
-
-    }
-
-    pub unsafe fn get_particle_position(
-        &self,
-        positions: *const OpenMM_Vec3Array,
-        index: i32,
-    ) -> Coordinate {
-
-        let particle_position = OpenMM_Vec3_scale(*OpenMM_Vec3Array_get(positions, index), 1.0);
-        let position = [
-            particle_position.x,
-            particle_position.y,
-            particle_position.z,
-        ];
-
-        position
+        positions
 
     }
 

--- a/nanover-rs/src/simulation.rs
+++ b/nanover-rs/src/simulation.rs
@@ -537,7 +537,6 @@ impl OpenMMSimulation {
     }
 
     pub unsafe fn get_positions(&self) -> Vec<Coordinate> {
-
         let state = OpenMM_Context_getState(
             self.context,
             OpenMM_State_DataType_OpenMM_State_Positions as i32,
@@ -548,7 +547,8 @@ impl OpenMMSimulation {
         let mut positions = Vec::<Coordinate>::new();
 
         for index in 0..self.n_particles {
-            let particle_position = OpenMM_Vec3_scale(*OpenMM_Vec3Array_get(pos_state, index as i32), 1.0);
+            let particle_position =
+                OpenMM_Vec3_scale(*OpenMM_Vec3Array_get(pos_state, index as i32), 1.0);
             let position = [
                 particle_position.x,
                 particle_position.y,
@@ -560,7 +560,6 @@ impl OpenMMSimulation {
         OpenMM_State_destroy(state);
 
         positions
-
     }
 
     pub fn get_potential_energy(&self) -> f64 {

--- a/nanover-rs/src/simulation.rs
+++ b/nanover-rs/src/simulation.rs
@@ -536,36 +536,36 @@ impl OpenMMSimulation {
         }
     }
 
-    pub fn get_positions(&self) -> *const OpenMM_Vec3Array {
-        unsafe {
-            let state = OpenMM_Context_getState(
-                self.context,
-                OpenMM_State_DataType_OpenMM_State_Positions as i32,
-                0,
-            );
-            let pos_state = OpenMM_State_getPositions(state);
+    unsafe fn get_positions(&self) -> *const OpenMM_Vec3Array {
 
-            OpenMM_State_destroy(state);
+        let state = OpenMM_Context_getState(
+            self.context,
+            OpenMM_State_DataType_OpenMM_State_Positions as i32,
+            0,
+        );
+        let pos_state = OpenMM_State_getPositions(state);
 
-            pos_state
-        }
+        OpenMM_State_destroy(state);
+
+        pos_state
+
     }
 
-    pub fn get_particle_position(
+    unsafe fn get_particle_position(
         &self,
         positions: *const OpenMM_Vec3Array,
         index: i32,
     ) -> Coordinate {
-        unsafe {
-            let particle_position = OpenMM_Vec3_scale(*OpenMM_Vec3Array_get(positions, index), 1.0);
-            let position = [
-                particle_position.x,
-                particle_position.y,
-                particle_position.z,
-            ];
 
-            position
-        }
+        let particle_position = OpenMM_Vec3_scale(*OpenMM_Vec3Array_get(positions, index), 1.0);
+        let position = [
+            particle_position.x,
+            particle_position.y,
+            particle_position.z,
+        ];
+
+        position
+
     }
 
     pub fn get_potential_energy(&self) -> f64 {

--- a/nanover-rs/src/simulation.rs
+++ b/nanover-rs/src/simulation.rs
@@ -536,6 +536,10 @@ impl OpenMMSimulation {
         }
     }
 
+    /// # Safety
+    ///
+    /// This function returns the positions of the system from an OpenMM state, but perhaps it is only necessary to retrieve the selection positions
+    /// TODO: investigate whether this function can be rewritten to only return desired selections
     pub unsafe fn get_positions(&self) -> Vec<Coordinate> {
         let state = OpenMM_Context_getState(
             self.context,

--- a/nanover-rs/src/simulation.rs
+++ b/nanover-rs/src/simulation.rs
@@ -557,9 +557,8 @@ impl OpenMMSimulation {
         index: i32,
     ) -> Coordinate {
         unsafe {
-            let mut position;
             let particle_position = OpenMM_Vec3_scale(*OpenMM_Vec3Array_get(positions, index), 1.0);
-            position = [
+            let position = [
                 particle_position.x,
                 particle_position.y,
                 particle_position.z,

--- a/nanover-rs/src/simulation.rs
+++ b/nanover-rs/src/simulation.rs
@@ -551,14 +551,14 @@ impl OpenMMSimulation {
         }
     }
 
-    pub fn get_particle_position(&self, positions: *const OpenMM_Vec3Array, index: i32) -> Coordinate {
-
-        unsafe{
-            let mut position = [0.0, 0.0, 0.0];
-            let particle_position = OpenMM_Vec3_scale(
-                *OpenMM_Vec3Array_get(positions, index),
-                1.0
-            );
+    pub fn get_particle_position(
+        &self,
+        positions: *const OpenMM_Vec3Array,
+        index: i32,
+    ) -> Coordinate {
+        unsafe {
+            let mut position;
+            let particle_position = OpenMM_Vec3_scale(*OpenMM_Vec3Array_get(positions, index), 1.0);
             position = [
                 particle_position.x,
                 particle_position.y,
@@ -566,9 +566,7 @@ impl OpenMMSimulation {
             ];
 
             position
-
         }
-
     }
 
     pub fn get_potential_energy(&self) -> f64 {

--- a/nanover-rs/src/tracked_simulation/openmm.rs
+++ b/nanover-rs/src/tracked_simulation/openmm.rs
@@ -244,18 +244,18 @@ fn add_force_map_to_frame(force_map: &CoordMap, frame: &mut FrameData) {
 }
 
 fn compute_potential_energy_correction(force_map: &CoordMap, simulation: &OpenMMSimulation) -> f64 {
-    unsafe {
-        let positions = simulation.get_positions();
-        let mut energy_correction = 0.0;
-        let n_particles = force_map.len();
 
-        for particle in 0..n_particles {
-            let pos = simulation.get_particle_position(positions, particle as i32);
-            let force = force_map[&particle];
-            energy_correction =
-                energy_correction + force[0] * pos[0] + force[1] * pos[1] + force[2] * pos[2]
-        }
+    let positions = simulation.get_positions();
+    let mut energy_correction = 0.0;
+    let n_particles = force_map.len();
 
-        energy_correction
+    for particle in 0..n_particles {
+        let pos = simulation.get_particle_position(positions, particle as i32);
+        let force = force_map[&particle];
+        energy_correction =
+            energy_correction + force[0] * pos[0] + force[1] * pos[1] + force[2] * pos[2]
     }
+
+    energy_correction
+
 }

--- a/nanover-rs/src/tracked_simulation/openmm.rs
+++ b/nanover-rs/src/tracked_simulation/openmm.rs
@@ -251,7 +251,7 @@ fn compute_potential_energy_correction(force_map: &CoordMap, simulation: &OpenMM
         let n_particles = force_map.len();
 
         for particle in 0..n_particles {
-            let pos = simulation.get_particle_position(positions, particle as i32);
+            let pos = positions[particle];
             let force = force_map[&particle];
             energy_correction =
                 energy_correction + force[0] * pos[0] + force[1] * pos[1] + force[2] * pos[2]

--- a/nanover-rs/src/tracked_simulation/openmm.rs
+++ b/nanover-rs/src/tracked_simulation/openmm.rs
@@ -244,7 +244,6 @@ fn add_force_map_to_frame(force_map: &CoordMap, frame: &mut FrameData) {
 }
 
 fn compute_potential_energy_correction(force_map: &CoordMap, simulation: &OpenMMSimulation) -> f64 {
-
     unsafe {
         let positions = simulation.get_positions();
         let mut energy_correction = 0.0;
@@ -258,5 +257,4 @@ fn compute_potential_energy_correction(force_map: &CoordMap, simulation: &OpenMM
 
         energy_correction
     }
-
 }

--- a/nanover-rs/src/tracked_simulation/openmm.rs
+++ b/nanover-rs/src/tracked_simulation/openmm.rs
@@ -245,17 +245,19 @@ fn add_force_map_to_frame(force_map: &CoordMap, frame: &mut FrameData) {
 
 fn compute_potential_energy_correction(force_map: &CoordMap, simulation: &OpenMMSimulation) -> f64 {
 
-    let positions = simulation.get_positions();
-    let mut energy_correction = 0.0;
-    let n_particles = force_map.len();
+    unsafe {
+        let positions = simulation.get_positions();
+        let mut energy_correction = 0.0;
+        let n_particles = force_map.len();
 
-    for particle in 0..n_particles {
-        let pos = simulation.get_particle_position(positions, particle as i32);
-        let force = force_map[&particle];
-        energy_correction =
-            energy_correction + force[0] * pos[0] + force[1] * pos[1] + force[2] * pos[2]
+        for particle in 0..n_particles {
+            let pos = simulation.get_particle_position(positions, particle as i32);
+            let force = force_map[&particle];
+            energy_correction =
+                energy_correction + force[0] * pos[0] + force[1] * pos[1] + force[2] * pos[2]
+        }
+
+        energy_correction
     }
-
-    energy_correction
 
 }

--- a/nanover-rs/src/tracked_simulation/openmm.rs
+++ b/nanover-rs/src/tracked_simulation/openmm.rs
@@ -246,7 +246,7 @@ fn add_force_map_to_frame(force_map: &CoordMap, frame: &mut FrameData) {
 fn compute_potential_energy_correction(force_map: &CoordMap, simulation: &OpenMMSimulation) -> f64 {
     unsafe {
         let selection = force_map.keys().map(|value| *value as i32).collect();
-        let positions = simulation.get_selected_positions_coord_map(&selection);
+        let positions = simulation.get_selected_positions(&selection);
         let mut energy_correction = 0.0;
 
         for particle in force_map.keys() {

--- a/nanover-rs/src/tracked_simulation/openmm.rs
+++ b/nanover-rs/src/tracked_simulation/openmm.rs
@@ -250,7 +250,7 @@ fn compute_potential_energy_correction(force_map: &CoordMap, simulation: &OpenMM
 
         for particle in force_map.keys() {
             let pos = positions[*particle];
-            let force = force_map[&particle];
+            let force = force_map[particle];
             energy_correction =
                 energy_correction + force[0] * pos[0] + force[1] * pos[1] + force[2] * pos[2]
         }

--- a/nanover-rs/src/tracked_simulation/openmm.rs
+++ b/nanover-rs/src/tracked_simulation/openmm.rs
@@ -248,10 +248,9 @@ fn compute_potential_energy_correction(force_map: &CoordMap, simulation: &OpenMM
     unsafe {
         let positions = simulation.get_positions();
         let mut energy_correction = 0.0;
-        let n_particles = force_map.len();
 
-        for particle in 0..n_particles {
-            let pos = positions[particle];
+        for particle in force_map.keys() {
+            let pos = positions[*particle];
             let force = force_map[&particle];
             energy_correction =
                 energy_correction + force[0] * pos[0] + force[1] * pos[1] + force[2] * pos[2]

--- a/nanover-rs/src/tracked_simulation/openmm.rs
+++ b/nanover-rs/src/tracked_simulation/openmm.rs
@@ -259,19 +259,3 @@ fn compute_potential_energy_correction(force_map: &CoordMap, simulation: &OpenMM
         energy_correction
     }
 }
-
-// fn compute_potential_energy_correction_selected(force_map: &CoordMap, simulation: &OpenMMSimulation) -> f64 {
-//     unsafe {
-//         let positions = simulation.get_positions();
-//         let mut energy_correction = 0.0;
-//
-//         for particle in force_map.keys() {
-//             let pos = positions[*particle];
-//             let force = force_map[particle];
-//             energy_correction =
-//                 energy_correction + force[0] * pos[0] + force[1] * pos[1] + force[2] * pos[2]
-//         }
-//
-//         energy_correction
-//     }
-// }

--- a/nanover-rs/src/tracked_simulation/openmm.rs
+++ b/nanover-rs/src/tracked_simulation/openmm.rs
@@ -250,8 +250,8 @@ fn compute_potential_energy_correction(force_map: &CoordMap, simulation: &OpenMM
         let mut energy_correction = 0.0;
 
         for particle in force_map.keys() {
-            let pos = positions[&particle];
-            let force = force_map[&particle];
+            let pos = positions[particle];
+            let force = force_map[particle];
             energy_correction =
                 energy_correction + force[0] * pos[0] + force[1] * pos[1] + force[2] * pos[2]
         }

--- a/nanover-rs/src/tracked_simulation/openmm.rs
+++ b/nanover-rs/src/tracked_simulation/openmm.rs
@@ -245,12 +245,13 @@ fn add_force_map_to_frame(force_map: &CoordMap, frame: &mut FrameData) {
 
 fn compute_potential_energy_correction(force_map: &CoordMap, simulation: &OpenMMSimulation) -> f64 {
     unsafe {
-        let positions = simulation.get_positions();
+        let selection = force_map.keys().map(|value| *value as i32).collect();
+        let positions = simulation.get_selected_positions_coord_map(&selection);
         let mut energy_correction = 0.0;
 
         for particle in force_map.keys() {
-            let pos = positions[*particle];
-            let force = force_map[particle];
+            let pos = positions[&particle];
+            let force = force_map[&particle];
             energy_correction =
                 energy_correction + force[0] * pos[0] + force[1] * pos[1] + force[2] * pos[2]
         }
@@ -258,3 +259,19 @@ fn compute_potential_energy_correction(force_map: &CoordMap, simulation: &OpenMM
         energy_correction
     }
 }
+
+// fn compute_potential_energy_correction_selected(force_map: &CoordMap, simulation: &OpenMMSimulation) -> f64 {
+//     unsafe {
+//         let positions = simulation.get_positions();
+//         let mut energy_correction = 0.0;
+//
+//         for particle in force_map.keys() {
+//             let pos = positions[*particle];
+//             let force = force_map[particle];
+//             energy_correction =
+//                 energy_correction + force[0] * pos[0] + force[1] * pos[1] + force[2] * pos[2]
+//         }
+//
+//         energy_correction
+//     }
+// }

--- a/nanover-rs/src/tracked_simulation/openmm.rs
+++ b/nanover-rs/src/tracked_simulation/openmm.rs
@@ -162,9 +162,8 @@ impl TrackedSimulation for TrackedOpenMMSimulation {
         let mut frame = self.simulation.to_framedata(with_velocities, with_forces);
         let energy_total = self.user_energies();
         let potential_energy = self.simulation.get_potential_energy();
-        let potential_energy_correction = compute_potential_energy_correction(
-            self.user_forces(),
-            &self.simulation);
+        let potential_energy_correction =
+            compute_potential_energy_correction(self.user_forces(), &self.simulation);
         frame
             .insert_number_value("energy.user.total", energy_total)
             .unwrap();
@@ -172,8 +171,10 @@ impl TrackedSimulation for TrackedOpenMMSimulation {
             .insert_number_value("system.reset.counter", self.reset_counter as f64)
             .unwrap();
         frame
-            .insert_number_value("energy.potential_corrected",
-                                 potential_energy + potential_energy_correction)
+            .insert_number_value(
+                "energy.potential_corrected",
+                potential_energy + potential_energy_correction,
+            )
             .unwrap();
         add_force_map_to_frame(self.user_forces(), &mut frame);
         let mut source = sim_clone.lock().unwrap();
@@ -242,22 +243,19 @@ fn add_force_map_to_frame(force_map: &CoordMap, frame: &mut FrameData) {
         .unwrap();
 }
 
-fn compute_potential_energy_correction(
-    force_map: &CoordMap,
-    simulation: &OpenMMSimulation)
-    -> f64 {
-        unsafe {
-            let positions = simulation.get_positions();
-            let mut energy_correction = 0.0;
-            let n_particles = force_map.len();
+fn compute_potential_energy_correction(force_map: &CoordMap, simulation: &OpenMMSimulation) -> f64 {
+    unsafe {
+        let positions = simulation.get_positions();
+        let mut energy_correction = 0.0;
+        let n_particles = force_map.len();
 
-            for particle in 0..n_particles {
-                    let pos = simulation.get_particle_position(positions, particle as i32);
-                    let force = force_map[&particle];
-                    energy_correction = energy_correction +
-                        force[0] * pos[0] + force[1] * pos[1] + force[2] * pos[2]
-            }
-
-            energy_correction
+        for particle in 0..n_particles {
+            let pos = simulation.get_particle_position(positions, particle as i32);
+            let force = force_map[&particle];
+            energy_correction =
+                energy_correction + force[0] * pos[0] + force[1] * pos[1] + force[2] * pos[2]
         }
+
+        energy_correction
     }
+}


### PR DESCRIPTION
This PR adds another value field to the FrameData ("energy.potential_corrected") that should solve Issue #228. At some point we may want to correct the potential energy directly, but that is beyond the scope of this fix.