### PR TITLE
Move IMD force to different group number so it's ignored in potential energy calculation

### DIFF
--- a/nanover-rs/src/simulation.rs
+++ b/nanover-rs/src/simulation.rs
@@ -496,7 +496,7 @@ impl OpenMMSimulation {
     unsafe fn add_imd_force(n_particles: i32) -> *mut OpenMM_CustomExternalForce {
         let energy_expression = CString::new("-fx * x - fy * y - fz * z").unwrap();
         let force = OpenMM_CustomExternalForce_create(energy_expression.into_raw() as *const i8);
-        OpenMM_Force_setForceGroup(force.try_into().unwrap(), 31);
+        OpenMM_Force_setForceGroup(force as OpenMM_Force, 31);
         OpenMM_CustomExternalForce_addPerParticleParameter(
             force,
             CString::new("fx").unwrap().into_raw(),

--- a/nanover-rs/src/simulation.rs
+++ b/nanover-rs/src/simulation.rs
@@ -496,7 +496,7 @@ impl OpenMMSimulation {
     unsafe fn add_imd_force(n_particles: i32) -> *mut OpenMM_CustomExternalForce {
         let energy_expression = CString::new("-fx * x - fy * y - fz * z").unwrap();
         let force = OpenMM_CustomExternalForce_create(energy_expression.into_raw() as *const i8);
-        OpenMM_Force_setForceGroup(force as OpenMM_Force, 31);
+        OpenMM_Force_setForceGroup(force as *mut OpenMM_Force, 31);
         OpenMM_CustomExternalForce_addPerParticleParameter(
             force,
             CString::new("fx").unwrap().into_raw(),

--- a/nanover-rs/src/simulation.rs
+++ b/nanover-rs/src/simulation.rs
@@ -23,7 +23,7 @@ use openmm_sys::{
     OpenMM_System_getParticleMass, OpenMM_Vec3, OpenMM_Vec3Array, OpenMM_Vec3Array_create,
     OpenMM_Vec3Array_destroy, OpenMM_Vec3Array_get, OpenMM_Vec3Array_getSize, OpenMM_Vec3Array_set,
     OpenMM_Vec3_scale, OpenMM_XmlSerializer_deserializeIntegrator,
-    OpenMM_XmlSerializer_deserializeSystem,
+    OpenMM_XmlSerializer_deserializeSystem, OpenMM_Force_setForceGroup,
 };
 use quick_xml::events::{BytesEnd, BytesStart, Event};
 use quick_xml::Reader;
@@ -496,6 +496,7 @@ impl OpenMMSimulation {
     unsafe fn add_imd_force(n_particles: i32) -> *mut OpenMM_CustomExternalForce {
         let energy_expression = CString::new("-fx * x - fy * y - fz * z").unwrap();
         let force = OpenMM_CustomExternalForce_create(energy_expression.into_raw() as *const i8);
+        OpenMM_Force_setForceGroup(force, 31);
         OpenMM_CustomExternalForce_addPerParticleParameter(
             force,
             CString::new("fx").unwrap().into_raw(),

--- a/nanover-rs/src/simulation.rs
+++ b/nanover-rs/src/simulation.rs
@@ -496,7 +496,7 @@ impl OpenMMSimulation {
     unsafe fn add_imd_force(n_particles: i32) -> *mut OpenMM_CustomExternalForce {
         let energy_expression = CString::new("-fx * x - fy * y - fz * z").unwrap();
         let force = OpenMM_CustomExternalForce_create(energy_expression.into_raw() as *const i8);
-        OpenMM_Force_setForceGroup(force, 31);
+        OpenMM_Force_setForceGroup(force.try_into().unwrap(), 31);
         OpenMM_CustomExternalForce_addPerParticleParameter(
             force,
             CString::new("fx").unwrap().into_raw(),

--- a/nanover-rs/src/simulation.rs
+++ b/nanover-rs/src/simulation.rs
@@ -10,9 +10,9 @@ use openmm_sys::{
     OpenMM_CustomExternalForce_addPerParticleParameter, OpenMM_CustomExternalForce_create,
     OpenMM_CustomExternalForce_setParticleParameters,
     OpenMM_CustomExternalForce_updateParametersInContext, OpenMM_DoubleArray_create,
-    OpenMM_DoubleArray_set, OpenMM_Force, OpenMM_Integrator, OpenMM_Integrator_destroy,
-    OpenMM_Integrator_step, OpenMM_Platform_getName, OpenMM_Platform_getNumPlatforms,
-    OpenMM_Platform_loadPluginsFromDirectory, OpenMM_State,
+    OpenMM_DoubleArray_set, OpenMM_Force, OpenMM_Force_setForceGroup, OpenMM_Integrator,
+    OpenMM_Integrator_destroy, OpenMM_Integrator_step, OpenMM_Platform_getName,
+    OpenMM_Platform_getNumPlatforms, OpenMM_Platform_loadPluginsFromDirectory, OpenMM_State,
     OpenMM_State_DataType_OpenMM_State_Energy, OpenMM_State_DataType_OpenMM_State_Forces,
     OpenMM_State_DataType_OpenMM_State_ParameterDerivatives,
     OpenMM_State_DataType_OpenMM_State_Parameters, OpenMM_State_DataType_OpenMM_State_Positions,
@@ -23,7 +23,7 @@ use openmm_sys::{
     OpenMM_System_getParticleMass, OpenMM_Vec3, OpenMM_Vec3Array, OpenMM_Vec3Array_create,
     OpenMM_Vec3Array_destroy, OpenMM_Vec3Array_get, OpenMM_Vec3Array_getSize, OpenMM_Vec3Array_set,
     OpenMM_Vec3_scale, OpenMM_XmlSerializer_deserializeIntegrator,
-    OpenMM_XmlSerializer_deserializeSystem, OpenMM_Force_setForceGroup,
+    OpenMM_XmlSerializer_deserializeSystem,
 };
 use quick_xml::events::{BytesEnd, BytesStart, Event};
 use quick_xml::Reader;

--- a/nanover-rs/src/simulation.rs
+++ b/nanover-rs/src/simulation.rs
@@ -638,7 +638,6 @@ impl ToFrameData for OpenMMSimulation {
         let mut box_vectors = Vec::<f32>::new();
         let potential_energy;
         let kinetic_energy;
-        let total_energy;
         let time;
 
         let mut state_options = OpenMM_State_DataType_OpenMM_State_Positions

--- a/nanover-rs/src/simulation.rs
+++ b/nanover-rs/src/simulation.rs
@@ -654,7 +654,6 @@ impl ToFrameData for OpenMMSimulation {
 
             potential_energy = OpenMM_State_getPotentialEnergy(state);
             kinetic_energy = OpenMM_State_getKineticEnergy(state);
-            total_energy = potential_energy + kinetic_energy;
 
             time = OpenMM_State_getTime(state);
 
@@ -723,9 +722,6 @@ impl ToFrameData for OpenMMSimulation {
             .insert_number_value("energy.kinetic", kinetic_energy)
             .unwrap();
         frame
-            .insert_number_value("energy.total", total_energy)
-            .unwrap();
-        frame
             .insert_number_value("system.simulation.time", time)
             .unwrap();
         frame
@@ -743,7 +739,7 @@ impl ToFrameData for OpenMMSimulation {
                 .unwrap();
         }
         if with_forces {
-            frame.insert_float_array("particle.forces", forces).unwrap();
+            frame.insert_float_array("particle.forces.system", forces).unwrap();
         }
 
         frame

--- a/nanover-rs/src/simulation.rs
+++ b/nanover-rs/src/simulation.rs
@@ -739,7 +739,9 @@ impl ToFrameData for OpenMMSimulation {
                 .unwrap();
         }
         if with_forces {
-            frame.insert_float_array("particle.forces.system", forces).unwrap();
+            frame
+                .insert_float_array("particle.forces.system", forces)
+                .unwrap();
         }
 
         frame

--- a/nanover-rs/src/tracked_simulation/openmm.rs
+++ b/nanover-rs/src/tracked_simulation/openmm.rs
@@ -168,12 +168,6 @@ impl TrackedSimulation for TrackedOpenMMSimulation {
         frame
             .insert_number_value("system.reset.counter", self.reset_counter as f64)
             .unwrap();
-        frame
-            .insert_number_value(
-                "energy.potential_corrected",
-                potential_energy + potential_energy_correction,
-            )
-            .unwrap();
         add_force_map_to_frame(self.user_forces(), &mut frame);
         let mut source = sim_clone.lock().unwrap();
         source.send_frame(frame)

--- a/nanover-rs/src/tracked_simulation/openmm.rs
+++ b/nanover-rs/src/tracked_simulation/openmm.rs
@@ -161,7 +161,6 @@ impl TrackedSimulation for TrackedOpenMMSimulation {
     ) -> Result<(), BroadcastSendError> {
         let mut frame = self.simulation.to_framedata(with_velocities, with_forces);
         let energy_total = self.user_energies();
-        let potential_energy = self.simulation.get_potential_energy();
         frame
             .insert_number_value("energy.user.total", energy_total)
             .unwrap();

--- a/nanover-rs/src/tracked_simulation/openmm.rs
+++ b/nanover-rs/src/tracked_simulation/openmm.rs
@@ -161,13 +161,7 @@ impl TrackedSimulation for TrackedOpenMMSimulation {
     ) -> Result<(), BroadcastSendError> {
         let mut frame = self.simulation.to_framedata(with_velocities, with_forces);
         let energy_total = self.user_energies();
-        // It would be better to simply amend the potential energy in the frame. This would avoid
-        // having to retrieve it again from the OpenMM state again (as below) and writing the
-        // corrected potential energy to the frame in a new field (energy.potential_corrected)
-        // TODO: Add functionality to amend values of fields in FrameData
         let potential_energy = self.simulation.get_potential_energy();
-        let potential_energy_correction =
-            compute_potential_energy_correction(self.user_forces(), &self.simulation);
         frame
             .insert_number_value("energy.user.total", energy_total)
             .unwrap();
@@ -245,27 +239,4 @@ fn add_force_map_to_frame(force_map: &CoordMap, frame: &mut FrameData) {
     frame
         .insert_float_array("forces.user.sparse", sparse)
         .unwrap();
-}
-
-// Currently, this function has to retrieve the positions of the atoms with which the user is
-// interacting from OpenMM in a way that is separate to what is currently happening for the frame.
-// It would be good to think of a way to avoid doing this, as this information must already be
-// accessed to calculate the forces from the interactions.
-// TODO: Investigate whether this function can be reworked to avoid retrieving the positions from
-//       the OpenMM state again here
-fn compute_potential_energy_correction(force_map: &CoordMap, simulation: &OpenMMSimulation) -> f64 {
-    unsafe {
-        let selection = force_map.keys().map(|value| *value as i32).collect();
-        let positions = simulation.get_selected_positions(&selection);
-        let mut energy_correction = 0.0;
-
-        for particle in force_map.keys() {
-            let pos = positions[particle];
-            let force = force_map[particle];
-            energy_correction =
-                energy_correction + force[0] * pos[0] + force[1] * pos[1] + force[2] * pos[2]
-        }
-
-        energy_correction
-    }
 }


### PR DESCRIPTION
This should exclude the IMD force from the potential energy calculation. ~It will also exclude the force from other things, but I'm not sure if that affects anything?~

~--actually it may mean the reported particle forces don't include IMD interactions, which is maybe a problem or is maybe fine since they will be in the user forces array?~

Corresponds to these changes: https://github.com/IRL2/nanover-protocol/pull/223 and https://github.com/IRL2/nanover-protocol/pull/222